### PR TITLE
Builder.warn was deprecated

### DIFF
--- a/sphinxcontrib/nwdiag.py
+++ b/sphinxcontrib/nwdiag.py
@@ -21,6 +21,7 @@ from collections import namedtuple
 from docutils import nodes
 from sphinx import addnodes
 from sphinx.util.osutil import ensuredir
+from sphinx.util import logging
 
 import nwdiag.utils.rst.nodes
 import nwdiag.utils.rst.directives
@@ -32,6 +33,7 @@ from blockdiag.utils.rst.directives import with_blockdiag
 # fontconfig; it will be initialized on `builder-inited` event.
 fontmap = None
 
+logger = logging.getLogger(__name__)
 
 class nwdiag_node(nwdiag.utils.rst.nodes.nwdiag):
     def to_drawer(self, image_format, builder, **kwargs):
@@ -110,7 +112,7 @@ def resolve_reference(builder, href):
             else:
                 return xref['refuri']
         else:
-            builder.warn('undefined label: %s' % refid)
+            logger.warn('undefined label: %s' % refid)
             return None
 
 
@@ -212,13 +214,13 @@ def html_visit_nwdiag(self, node):
 
         msg = ("nwdiag error: UnicodeEncodeError caught "
                "(check your font settings)")
-        self.builder.warn(msg)
+        logger.warn(msg)
         raise nodes.SkipNode
     except Exception as exc:
         if self.builder.config.nwdiag_debug:
             traceback.print_exc()
 
-        self.builder.warn('dot code %r: %s' % (node['code'], str(exc)))
+        logger.warn('dot code %r: %s' % (node['code'], str(exc)))
         raise nodes.SkipNode
 
 
@@ -253,7 +255,7 @@ def get_image_format_for(builder):
 def on_builder_inited(self):
     # show deprecated message
     if self.builder.config.nwdiag_tex_image_format:
-        self.builder.warn('nwdiag_tex_image_format is deprecated. Use nwdiag_latex_image_format.')
+        logger.warn('nwdiag_tex_image_format is deprecated. Use nwdiag_latex_image_format.')
 
     # initialize fontmap
     global fontmap
@@ -287,7 +289,7 @@ def on_doctree_resolved(self, doctree, docname):
         if self.builder.config.nwdiag_debug:
             traceback.print_exc()
 
-        self.builder.warn('nwdiag error: %s' % exc)
+        logger.warn('nwdiag error: %s' % exc)
         for node in doctree.traverse(nwdiag_node):
             node.parent.remove(node)
 
@@ -308,7 +310,7 @@ def on_doctree_resolved(self, doctree, docname):
             if self.builder.config.nwdiag_debug:
                 traceback.print_exc()
 
-            self.builder.warn('dot code %r: %s' % (node['code'], str(exc)))
+            logger.warn('dot code %r: %s' % (node['code'], str(exc)))
             node.parent.remove(node)
 
 

--- a/sphinxcontrib/packetdiag.py
+++ b/sphinxcontrib/packetdiag.py
@@ -21,6 +21,7 @@ from collections import namedtuple
 from docutils import nodes
 from sphinx import addnodes
 from sphinx.util.osutil import ensuredir
+from sphinx.util import logging
 
 import packetdiag.utils.rst.nodes
 import packetdiag.utils.rst.directives
@@ -32,6 +33,7 @@ from blockdiag.utils.rst.directives import with_blockdiag
 # fontconfig; it will be initialized on `builder-inited` event.
 fontmap = None
 
+logger = logging.getLogger(__name__)
 
 class packetdiag_node(packetdiag.utils.rst.nodes.packetdiag):
     def to_drawer(self, image_format, builder, **kwargs):
@@ -110,7 +112,7 @@ def resolve_reference(builder, href):
             else:
                 return xref['refuri']
         else:
-            builder.warn('undefined label: %s' % refid)
+            logger.warn('undefined label: %s' % refid)
             return None
 
 
@@ -212,13 +214,13 @@ def html_visit_packetdiag(self, node):
 
         msg = ("packetdiag error: UnicodeEncodeError caught "
                "(check your font settings)")
-        self.builder.warn(msg)
+        logger.warn(msg)
         raise nodes.SkipNode
     except Exception as exc:
         if self.builder.config.packetdiag_debug:
             traceback.print_exc()
 
-        self.builder.warn('dot code %r: %s' % (node['code'], str(exc)))
+        logger.warn('dot code %r: %s' % (node['code'], str(exc)))
         raise nodes.SkipNode
 
 
@@ -253,7 +255,7 @@ def get_image_format_for(builder):
 def on_builder_inited(self):
     # show deprecated message
     if self.builder.config.packetdiag_tex_image_format:
-        self.builder.warn('packetdiag_tex_image_format is deprecated. Use packetdiag_latex_image_format.')
+        logger.warn('packetdiag_tex_image_format is deprecated. Use packetdiag_latex_image_format.')
 
     # initialize fontmap
     global fontmap
@@ -287,7 +289,7 @@ def on_doctree_resolved(self, doctree, docname):
         if self.builder.config.packetdiag_debug:
             traceback.print_exc()
 
-        self.builder.warn('packetdiag error: %s' % exc)
+        logger.warn('packetdiag error: %s' % exc)
         for node in doctree.traverse(packetdiag_node):
             node.parent.remove(node)
 
@@ -308,7 +310,7 @@ def on_doctree_resolved(self, doctree, docname):
             if self.builder.config.packetdiag_debug:
                 traceback.print_exc()
 
-            self.builder.warn('dot code %r: %s' % (node['code'], str(exc)))
+            logger.warn('dot code %r: %s' % (node['code'], str(exc)))
             node.parent.remove(node)
 
 

--- a/sphinxcontrib/rackdiag.py
+++ b/sphinxcontrib/rackdiag.py
@@ -21,6 +21,7 @@ from collections import namedtuple
 from docutils import nodes
 from sphinx import addnodes
 from sphinx.util.osutil import ensuredir
+from sphinx.util import logging
 
 import rackdiag.utils.rst.nodes
 import rackdiag.utils.rst.directives
@@ -32,6 +33,7 @@ from blockdiag.utils.rst.directives import with_blockdiag
 # fontconfig; it will be initialized on `builder-inited` event.
 fontmap = None
 
+logger = logging.getLogger(__name__)
 
 class rackdiag_node(rackdiag.utils.rst.nodes.rackdiag):
     def to_drawer(self, image_format, builder, **kwargs):
@@ -110,7 +112,7 @@ def resolve_reference(builder, href):
             else:
                 return xref['refuri']
         else:
-            builder.warn('undefined label: %s' % refid)
+            logger.warn('undefined label: %s' % refid)
             return None
 
 
@@ -212,13 +214,13 @@ def html_visit_rackdiag(self, node):
 
         msg = ("rackdiag error: UnicodeEncodeError caught "
                "(check your font settings)")
-        self.builder.warn(msg)
+        logger.warn(msg)
         raise nodes.SkipNode
     except Exception as exc:
         if self.builder.config.rackdiag_debug:
             traceback.print_exc()
 
-        self.builder.warn('dot code %r: %s' % (node['code'], str(exc)))
+        logger.warn('dot code %r: %s' % (node['code'], str(exc)))
         raise nodes.SkipNode
 
 
@@ -253,7 +255,7 @@ def get_image_format_for(builder):
 def on_builder_inited(self):
     # show deprecated message
     if self.builder.config.rackdiag_tex_image_format:
-        self.builder.warn('rackdiag_tex_image_format is deprecated. Use rackdiag_latex_image_format.')
+        logger.warn('rackdiag_tex_image_format is deprecated. Use rackdiag_latex_image_format.')
 
     # initialize fontmap
     global fontmap
@@ -287,7 +289,7 @@ def on_doctree_resolved(self, doctree, docname):
         if self.builder.config.rackdiag_debug:
             traceback.print_exc()
 
-        self.builder.warn('rackdiag error: %s' % exc)
+        logger.warn('rackdiag error: %s' % exc)
         for node in doctree.traverse(rackdiag_node):
             node.parent.remove(node)
 
@@ -308,7 +310,7 @@ def on_doctree_resolved(self, doctree, docname):
             if self.builder.config.rackdiag_debug:
                 traceback.print_exc()
 
-            self.builder.warn('dot code %r: %s' % (node['code'], str(exc)))
+            logger.warn('dot code %r: %s' % (node['code'], str(exc)))
             node.parent.remove(node)
 
 


### PR DESCRIPTION
`warn()` API was deprecated from 1.6 and removed from 2.0.

```
AttributeError: 'LaTeXBuilder' object has no attribute 'warn'
```

I replaced logger API to using `sphinx.util.logging`.